### PR TITLE
支持文本替换

### DIFF
--- a/example/config/color.xml
+++ b/example/config/color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<replace>
+    <rep src="t_red" dst="#123456"/>
+    <rep src="t_blue" dst="#123456"/>
+</replace>

--- a/example/config/equip/jewelry.csv
+++ b/example/config/equip/jewelry.csv
@@ -25,7 +25,7 @@ ID,Name,IconFile,LvlRank@Lvl,Rank,Type,SuitID,KeyAbility,KeyAbilityValue,SalePri
 23,地魁·虹涛珮,texture/t_jew_1_080.bundle,80,3,Jade,,2,330,1000,
 24,天堑·虹涛珮,texture/t_jew_1_084.bundle,80,4,Jade,6,2,360,1000,
 25,神王·虹涛珮,texture/t_jew_1_085.bundle,80,5,Jade,7,2,393,1000,
-26,梨木镯,texture/t_jew_2_010.bundle,5,1,Bracelet,,1,70,1000,种在地里多少年也不会长出梨的
+26,梨木镯,texture/t_jew_2_010.bundle,5,1,Bracelet,,1,70,1000,<color=t_red>种在地里多少年也不会长出梨的</color>
 27,人雄·梨木镯,texture/t_jew_2_010.bundle,5,2,Bracelet,,1,100,1000,种在地里多少年也不会长出梨的
 28,地魁·梨木镯,texture/t_jew_2_010.bundle,5,3,Bracelet,,1,130,1000,种在地里多少年也不会长出梨的
 29,天堑·梨木镯,texture/t_jew_2_014.bundle,5,4,Bracelet,,1,235,1000,种在地里多少年也不会长出梨的

--- a/example/gen.bat
+++ b/example/gen.bat
@@ -1,2 +1,2 @@
-java -Dfile.encoding=utf8 -jar ../configgen.jar -datadir config -gen lua,dir:lua,emmylua,sharedEmptyTable,shared -gen java,dir:java -gen cs,dir:cs -gen pack,dir:cs/cfg -gen javadata
+java -Dfile.encoding=utf8 -jar ../configgen.jar -datadir config -replace config/color.xml -gen lua,dir:lua,emmylua,sharedEmptyTable,shared -gen java,dir:java -gen cs,dir:cs -gen pack,dir:cs/cfg -gen javadata
 pause

--- a/src/configgen/gen/Context.java
+++ b/src/configgen/gen/Context.java
@@ -46,6 +46,7 @@ public class Context {
     private AllValue lastValue;
     private ViewFilter lastViewFilter;
 
+    private Replacement replacement;
 
     Context(Path dataDir, String encoding) {
         fullDefine = new AllDefine(dataDir, encoding);
@@ -68,6 +69,14 @@ public class Context {
         } else if (langSwitchDir != null) {
             langSwitch = new LangSwitch(langSwitchDir, i18nEncoding, crlfaslf);
         }
+    }
+
+    void setReplacement(String file) {
+        replacement = new Replacement(file);
+    }
+
+    public Replacement getReplacement() {
+        return replacement;
     }
 
     void dump() {

--- a/src/configgen/gen/Main.java
+++ b/src/configgen/gen/Main.java
@@ -99,6 +99,7 @@ public final class Main {
 
         String langSwitchDir = null;
 
+        String replaceFile = null;
 
         boolean verify = false;
         List<Generator> generators = new ArrayList<>();
@@ -135,6 +136,9 @@ public final class Main {
                     break;
                 case "-langSwitchDir":
                     langSwitchDir = args[++i];
+                    break;
+                case "-replace":
+                    replaceFile = args[++i];
                     break;
 
                 case "-v":
@@ -208,6 +212,10 @@ public final class Main {
         ctx.setI18nOrLangSwitch(i18nfile, langSwitchDir, i18nencoding, i18ncrlfaslf);
         if (dump) {
             ctx.dump();
+        }
+
+        if (replaceFile != null) {
+            ctx.setReplacement(replaceFile);
         }
 
         if (searchIntegers != null) {

--- a/src/configgen/gen/Replacement.java
+++ b/src/configgen/gen/Replacement.java
@@ -1,0 +1,30 @@
+package configgen.gen;
+
+import configgen.util.DomUtils;
+import org.w3c.dom.Element;
+
+import java.nio.file.Paths;
+import java.util.HashMap;
+
+public class Replacement {
+
+    private HashMap<String, String> src2dst = new HashMap<>();
+
+    public Replacement(String filePath) {
+        Element root = DomUtils.rootElement(Paths.get(filePath).toFile());
+        for (Element rep : DomUtils.elements(root, "rep")) {
+            var src = rep.getAttribute("src");
+            var dst = rep.getAttribute("dst");
+            src2dst.put(src, dst);
+        }
+    }
+
+    public String replace(String ori) {
+        final String[] target = {ori};
+        src2dst.forEach((src, dst) -> {
+            target[0] = target[0].replace(src, dst);
+        });
+        return target[0];
+    }
+
+}

--- a/src/configgen/value/VString.java
+++ b/src/configgen/value/VString.java
@@ -14,17 +14,20 @@ public class VString extends VPrimitive {
 
     VString(TString type, List<Cell> data) {
         super(type, data);
-
+        var ctx = AllValue.getCurrent().getCtx();
+        String sValue;
         if (type.subtype == TString.Subtype.STRING) {
-            value = raw.getData();
+            sValue = raw.getData();
         } else {
             String originalValue = raw.getData();
             String v = AllValue.getCurrent().getCtx().getI18n().enterText(originalValue);
-            value = v != null ? v : originalValue;
+            sValue = v != null ? v : originalValue;
             if (AllValue.getCurrent().getCtx().isI18n() && v == null && !originalValue.isEmpty()) {
                 System.out.println("未找到 " + type.fullName() + ": " + originalValue);
             }
         }
+        var replacement = ctx.getReplacement();
+        value = replacement == null ? sValue : replacement.replace(sValue);
     }
 
     @Override


### PR DESCRIPTION
支持策划在配置表中配颜色关键词的需求，比如‘<color=t_red>这是红色</color>’ 希望打表后替换成‘<color=#ff0000>这是红色</color>’。启动参数是-replace [xml file]，配置一个替换表，替换表的格式如下：
<replace>
    <rep src="color=t_red" dst="color=#123456"/>
    <rep src="color=t_blue" dst="color=#123456"/>
</replace>